### PR TITLE
增加pfx证书支持

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ chardet
 six
 xmltodict
 pycryptodome
+requests_pkcs12

--- a/weixin/pay.py
+++ b/weixin/pay.py
@@ -10,6 +10,7 @@ import string
 import random
 import socket
 
+import requests_pkcs12
 import six
 import requests
 import xmltodict
@@ -92,6 +93,7 @@ class WeixinPay(object):
         self.mch_key = kwargs.get('mch_key')
         self.notify_url = kwargs.get('notify_url')
         self.partner_key = kwargs.get('partner_key')
+        self.pfx = kwargs.get('pfx')
 
     def _full_url(self, path):
         return '%s%s' % (self.BASE_URL, path)
@@ -277,7 +279,11 @@ class WeixinPay(object):
         return self.make_request(method, url, kwargs)
 
     def make_request(self, method, url, kwargs):
-        req = requests.request(method, url, timeout=TIMEOUT, **kwargs)
+        if not self.pfx:
+            req = requests.request(method, url, timeout=TIMEOUT, **kwargs)
+        else:
+            req = requests_pkcs12.request(method, url, pkcs12_filename=self.pfx,
+                                          pkcs12_password=self.mch_id, timeout=TIMEOUT, **kwargs)
         # xml to dict
         result = xmltodict.parse(req.content)
         # 只需要返回数据

--- a/weixin/pay.py
+++ b/weixin/pay.py
@@ -540,6 +540,21 @@ class WeixinEnterprisePay(WeixinPay):
         method, url, kwargs = self.prepare_request('POST', path, params)
         return self.make_request(method, url, kwargs)
 
+    def get_transfer_info(self, partner_trade_no):
+        """
+        企业付款查询
+        https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=14_3
+        :param partner_trade_no: 商户订单号，默认自动生成
+        :return: 返回的结果数据
+        """
+        p = WeixinEnterprisePayQuery(appid=self.appid,
+                                     mch_id=self.mch_id,
+                                     mch_cert=self.mch_cert,
+                                     mch_key=self.mch_key,
+                                     pfx=self.pfx,
+                                     partner_key=self.partner_key)
+        return p.gettransferinfo(partner_trade_no)
+
 
 class WeixinEnterprisePayQuery(WeixinPay):
 


### PR DESCRIPTION
* 根据微信最新文档，除php外都应使用p12(pfx)证书，所有增加pfx证书支持。https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=4_3
* WeixinEnterprisePay 增加查询方法